### PR TITLE
Fix for kernel version >= 5.2.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+sudo make && make install
+sudo echo blacklist r8188eu > /etc/modprobe.d/realtek_blacklist.conf

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1098,8 +1098,10 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 	return dscp >> 5;
 }
 
-
-#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,19,0))
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(5,2,0))
+static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
+			    struct net_device *sb_dev)
+#elif (LINUX_VERSION_CODE>=KERNEL_VERSION(4,19,0))
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
 		struct net_device *sb_dev,
 		select_queue_fallback_t fallback)


### PR DESCRIPTION
Provide a method to shield the old driver in build.sh